### PR TITLE
hide arguments in debug trace page

### DIFF
--- a/admin-dev/functions.php
+++ b/admin-dev/functions.php
@@ -487,11 +487,11 @@ function runAdminTab($tab, $ajax_mode = false)
                                 if (is_array($admin_obj->table)) {
                                     foreach ($admin_obj->table as $table) {
                                         if (strncmp($key, $table.'Filter_', 7) === 0 || strncmp($key, 'submitFilter', 12) === 0) {
-                                            $cookie->$key = !is_array($value) ? $value : serialize($value);
+                                            $cookie->$key = !is_array($value) ? $value : json_encode($value);
                                         }
                                     }
                                 } elseif (strncmp($key, $admin_obj->table.'Filter_', 7) === 0 || strncmp($key, 'submitFilter', 12) === 0) {
-                                    $cookie->$key = !is_array($value) ? $value : serialize($value);
+                                    $cookie->$key = !is_array($value) ? $value : json_encode($value);
                                 }
                             }
                         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2557,7 +2557,7 @@ class CartCore extends ObjectModel
             $this->id_carrier = $this->getIdCarrierFromDeliveryOption($delivery_option);
         }
 
-        $this->delivery_option = serialize($delivery_option);
+        $this->delivery_option = json_encode($delivery_option);
     }
 
     protected function getIdCarrierFromDeliveryOption($delivery_option)
@@ -2596,26 +2596,29 @@ class CartCore extends ObjectModel
 
         // The delivery option was selected
         if (isset($this->delivery_option) && $this->delivery_option != '') {
-            $delivery_option = Tools::unSerialize($this->delivery_option);
-            $validated = false;
-            foreach ($delivery_option as $key) {
-                foreach ($delivery_option_list as $id_address => $option) {
-                    if (isset($delivery_option_list[$id_address][$key])) {
-                        $validated = true;
+            $delivery_option = json_decode($this->delivery_option, true);
+            if (is_array($delivery_option)) {
+                $validated = false;
+                foreach ($delivery_option as $key) {
+                    foreach ($delivery_option_list as $id_address => $option) {
+                        if (isset($delivery_option_list[$id_address][$key])) {
+                            $validated = true;
 
-                        if (!isset($delivery_option[$id_address])) {
-                            $delivery_option = array();
-                            $delivery_option[$id_address] = $key;
+                            if (!isset($delivery_option[$id_address])) {
+                                $delivery_option              = [];
+                                $delivery_option[$id_address] = $key;
+                            }
+
+                            break 2;
                         }
-
-                        break 2;
                     }
                 }
-            }
 
-            if ($validated) {
-                $cache[$cache_id] = $delivery_option;
-                return $delivery_option;
+                if ($validated) {
+                    $cache[$cache_id] = $delivery_option;
+
+                    return $delivery_option;
+                }
             }
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2605,7 +2605,7 @@ class CartCore extends ObjectModel
                             $validated = true;
 
                             if (!isset($delivery_option[$id_address])) {
-                                $delivery_option              = [];
+                                $delivery_option              = array();
                                 $delivery_option[$id_address] = $key;
                             }
 

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -405,7 +405,9 @@ class MailCore extends ObjectModel
                 'Swift Error: '.$e->getMessage(),
                 3,
                 null,
-                'Swift_Message'
+                'Swift_Message',
+                null,
+                true
             );
 
             return false;

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -177,47 +177,48 @@ class MailCore extends ObjectModel
             return false;
         }
 
-        /* Construct multiple recipients list if needed */
-        $message = Swift_Message::newInstance();
-        if (is_array($to) && isset($to)) {
-            foreach ($to as $key => $addr) {
-                $addr = trim($addr);
-                if (!Validate::isEmail($addr)) {
-                    Tools::dieOrLog(Tools::displayError('Error: invalid e-mail address'), $die);
-                    return false;
-                }
-
-                if (is_array($to_name) && isset($to_name[$key])) {
-                    $addrName = $to_name[$key];
-                } else {
-                    $addrName = $to_name;
-                }
-                
-                $addrName = (($addrName == null || $addrName == $addr || !Validate::isGenericName($addrName)) ? '' : self::mimeEncode($addrName));
-                $message->addTo($addr, $addrName);
-            }
-            $to_plugin = $to[0];
-        } else {
-            /* Simple recipient, one address */
-            $to_plugin = $to;
-            $to_name = (($to_name == null || $to_name == $to) ? '' : self::mimeEncode($to_name));
-            $message->addTo($to, $to_name);
-        }
-
-        if (isset($bcc) && is_array($bcc)) {
-            foreach ($bcc as $addr) {
-                $addr = trim($addr);
-                if (!Validate::isEmail($addr)) {
-                    Tools::dieOrLog(Tools::displayError('Error: invalid e-mail address'), $die);
-                    return false;
-                }
-                $message->addBcc($addr);
-            }
-        } elseif (isset($bcc)) {
-            $message->addBcc($bcc);
-        }
-
         try {
+
+            /* Construct multiple recipients list if needed */
+            $message = Swift_Message::newInstance();
+            if (is_array($to) && isset($to)) {
+                foreach ($to as $key => $addr) {
+                    $addr = trim($addr);
+                    if (!Validate::isEmail($addr)) {
+                        Tools::dieOrLog(Tools::displayError('Error: invalid e-mail address'), $die);
+                        return false;
+                    }
+
+                    if (is_array($to_name) && isset($to_name[$key])) {
+                        $addrName = $to_name[$key];
+                    } else {
+                        $addrName = $to_name;
+                    }
+
+                    $addrName = (($addrName == null || $addrName == $addr || !Validate::isGenericName($addrName)) ? '' : self::mimeEncode($addrName));
+                    $message->addTo($addr, $addrName);
+                }
+                $to_plugin = $to[0];
+            } else {
+                /* Simple recipient, one address */
+                $to_plugin = $to;
+                $to_name = (($to_name == null || $to_name == $to) ? '' : self::mimeEncode($to_name));
+                $message->addTo($to, $to_name);
+            }
+
+            if (isset($bcc) && is_array($bcc)) {
+                foreach ($bcc as $addr) {
+                    $addr = trim($addr);
+                    if (!Validate::isEmail($addr)) {
+                        Tools::dieOrLog(Tools::displayError('Error: invalid e-mail address'), $die);
+                        return false;
+                    }
+                    $message->addBcc($addr);
+                }
+            } elseif (isset($bcc)) {
+                $message->addBcc($bcc);
+            }
+
             /* Connect with the appropriate configuration */
             if ($configuration['PS_MAIL_METHOD'] == 2) {
                 if (empty($configuration['PS_MAIL_SERVER']) || empty($configuration['PS_MAIL_SMTP_PORT'])) {

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -156,7 +156,7 @@ class ValidateCore
      */
     public static function isName($name)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:]*$/u'), stripslashes($name));
+        return preg_match(Tools::cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u'), stripslashes($name));
     }
 
     /**

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -671,7 +671,7 @@ class AdminControllerCore extends Controller
                         if (isset($t['type']) && $t['type'] == 'bool') {
                             $filter_value = ((bool)$val) ? $this->l('yes') : $this->l('no');
                         } elseif (isset($t['type']) && $t['type'] == 'date' || isset($t['type']) && $t['type'] == 'datetime') {
-                            $date = Tools::unSerialize($val);
+                            $date = json_decode($val, true);
                             if (isset($date[0])) {
                                 $filter_value = $date[0];
                                 if (isset($date[1]) && !empty($date[1])) {
@@ -781,17 +781,17 @@ class AdminControllerCore extends Controller
                 if ($value === '') {
                     unset($this->context->cookie->{$prefix.$key});
                 } elseif (stripos($key, $this->list_id.'Filter_') === 0) {
-                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : json_encode($value);
                 } elseif (stripos($key, 'submitFilter') === 0) {
-                    $this->context->cookie->$key = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->$key = !is_array($value) ? $value : json_encode($value);
                 }
             }
 
             foreach ($_GET as $key => $value) {
                 if (stripos($key, $this->list_id.'Filter_') === 0) {
-                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : json_encode($value);
                 } elseif (stripos($key, 'submitFilter') === 0) {
-                    $this->context->cookie->$key = !is_array($value) ? $value : serialize($value);
+                    $this->context->cookie->$key = !is_array($value) ? $value : json_encode($value);
                 }
                 if (stripos($key, $this->list_id.'Orderby') === 0 && Validate::isOrderBy($value)) {
                     if ($value === '' || $value == $this->_defaultOrderBy) {
@@ -826,7 +826,7 @@ class AdminControllerCore extends Controller
                 if ($field = $this->filterToField($key, $filter)) {
                     $type = (array_key_exists('filter_type', $field) ? $field['filter_type'] : (array_key_exists('type', $field) ? $field['type'] : false));
                     if (($type == 'date' || $type == 'datetime') && is_string($value)) {
-                        $value = Tools::unSerialize($value);
+                        $value = json_decode($value, true);
                     }
                     $key = isset($tmp_tab[1]) ? $tmp_tab[0].'.`'.$tmp_tab[1].'`' : '`'.$tmp_tab[0].'`';
 

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -147,7 +147,7 @@ class PrestaShopExceptionCore extends Exception
         );
         $hiddenArgs = array();
         try {
-            $class = new \ReflectionClass($trace['class']);
+            $class = new ReflectionClass($trace['class']);
             /** @var \ReflectionMethod $method */
             $method = $class->getMethod($trace['function']);
             /** @var \ReflectionParameter $parameter */

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -35,7 +35,7 @@ class PrestaShopExceptionCore extends Exception
     public function displayMessage()
     {
         header('HTTP/1.1 500 Internal Server Error');
-        if (_PS_MODE_DEV_ || defined('_PS_ADMIN_DIR_')) {
+        if (_PS_MODE_DEV_) {
             // Display error message
             echo '<style>
 				#psException{font-family: Verdana; font-size: 14px}
@@ -74,7 +74,8 @@ class PrestaShopExceptionCore extends Exception
                     $this->displayFileDebug($trace['file'], $trace['line'], $id);
                 }
                 if (isset($trace['args']) && count($trace['args'])) {
-                    $this->displayArgsDebug($trace['args'], $id);
+                    $args = $this->hideCriticalArgs($trace);
+                    $this->displayArgsDebug($args, $id);
                 }
                 echo '</li>';
             }
@@ -120,6 +121,52 @@ class PrestaShopExceptionCore extends Exception
             }
         }
         echo '</pre></div>';
+    }
+
+    /**
+     * Prevent critical arguments to be displayed in the debug trace page (e.g. database password)
+     * Returns the array of args with critical arguments replaced by placeholders
+     *
+     * @param array $trace
+     * @return array
+     */
+    protected function hideCriticalArgs(array $trace)
+    {
+        $args = $trace['args'];
+        if (empty($trace['class']) || empty($trace['function'])) {
+            return $args;
+        }
+
+        $criticalParameters = array(
+            'pwd',
+            'pass',
+            'passwd',
+            'password',
+            'database',
+            'server',
+        );
+        $hiddenArgs = array();
+        try {
+            $class = new \ReflectionClass($trace['class']);
+            /** @var \ReflectionMethod $method */
+            $method = $class->getMethod($trace['function']);
+            /** @var \ReflectionParameter $parameter */
+            foreach ($method->getParameters() as $argIndex => $parameter) {
+                if ($argIndex >= count($args)) {
+                    break;
+                }
+
+                if (in_array(strtolower($parameter->getName()), $criticalParameters)) {
+                    $hiddenArgs[] = '**hidden_' . $parameter->getName() . '**';
+                } else {
+                    $hiddenArgs[] = $args[$argIndex];
+                }
+            }
+        } catch (ReflectionException $e) {
+            //In worst case scenario there are some critical args we could't detect so we return an empty array
+        }
+
+        return $hiddenArgs;
     }
 
     /**

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -613,7 +613,7 @@ class HelperListCore extends Helper
                 case 'date':
                 case 'datetime':
                     if (is_string($value)) {
-                        $value = Tools::unSerialize($value);
+                        $value = json_decode($value, true);
                     }
                     if (!Validate::isCleanHtml($value[0]) || !Validate::isCleanHtml($value[1])) {
                         $value = '';

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -827,7 +827,7 @@ class AdminModulesControllerCore extends AdminController
                         $this->errors[] = Tools::displayError('You do not have permission to install this module.');
                     } elseif ($key == 'delete' && ($this->tabAccess['delete'] !== '1' || !$module->getPermission('configure'))) {
                         $this->errors[] = Tools::displayError('You do not have permission to delete this module.');
-                    } elseif ($key == 'configure' && ($this->tabAccess['edit'] !== '1' || !$module->getPermission('configure') || !Module::isInstalled(urldecode($name)))) {
+                    } elseif ($key == 'configure' && (!$module->getPermission('configure') || !Module::isInstalled(urldecode($name)))) {
                         $this->errors[] = Tools::displayError('You do not have permission to configure this module.');
                     } elseif ($key == 'install' && Module::isInstalled($module->name)) {
                         $this->errors[] = sprintf(Tools::displayError('This module is already installed: %s.'), $module->name);

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1334,6 +1334,8 @@ class AdminOrdersControllerCore extends AdminController
             if ($this->tabAccess['edit'] === '1') {
                 if (!Tools::getValue('discount_name')) {
                     $this->errors[] = Tools::displayError('You must specify a name in order to create a new discount.');
+                } elseif ((float)Tools::getValue('discount_value') <= 0) {
+                    $this->errors[] = Tools::displayError('The discount value is invalid.');
                 } else {
                     if ($order->hasInvoice()) {
                         // If the discount is for only one invoice

--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -187,13 +187,10 @@ class ContactControllerCore extends FrontController
                         }
                     }
 
-                    if (empty($contact->email)) {
-                        Mail::Send($this->context->language->id, 'contact_form', ((isset($ct) && Validate::isLoadedObject($ct)) ? sprintf(Mail::l('Your message has been correctly sent #ct%1$s #tc%2$s'), $ct->id, $ct->token) : Mail::l('Your message has been correctly sent')), $var_list, $from, null, null, null, $file_attachment);
-                    } else {
+                    if (!empty($contact->email)) {
                         if (!Mail::Send($this->context->language->id, 'contact', Mail::l('Message from contact form').' [no_sync]',
                             $var_list, $contact->email, $contact->name, null, null,
-                                    $file_attachment, null,    _PS_MAIL_DIR_, false, null, null, $from) ||
-                                !Mail::Send($this->context->language->id, 'contact_form', ((isset($ct) && Validate::isLoadedObject($ct)) ? sprintf(Mail::l('Your message has been correctly sent #ct%1$s #tc%2$s'), $ct->id, $ct->token) : Mail::l('Your message has been correctly sent')), $var_list, $from, null, null, null, $file_attachment, null, _PS_MAIL_DIR_, false, null, null, $contact->email)) {
+                                    $file_attachment, null,    _PS_MAIL_DIR_, false, null, null, $from)) {
                             $this->errors[] = Tools::displayError('An error occurred while sending the message.');
                         }
                     }

--- a/install-dev/fixtures/fashion/data/cart.xml
+++ b/install-dev/fixtures/fashion/data/cart.xml
@@ -18,23 +18,23 @@
   </fields>
   <entities>
     <cart id="cart_1" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_2" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_3" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_4" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
     <cart id="cart_5" id_carrier="My_carrier" id_address_delivery="My_address" id_address_invoice="My_address" id_currency="1" id_customer="John" id_guest="guest_1" secure_key="b44a6d9efd7a0076a0fbce6b15eaf3b1" recyclable="0" gift="0" allow_seperated_package="0" id_shop="1" id_shop_group="1">
-      <delivery_option>a:1:{i:3;s:2:"2,";}</delivery_option>
+      <delivery_option>{"3":"2,"}</delivery_option>
       <gift_message/>
     </cart>
   </entities>

--- a/themes/default-bootstrap/order-opc-new-account.tpl
+++ b/themes/default-bootstrap/order-opc-new-account.tpl
@@ -185,12 +185,12 @@
 					{elseif $field_name eq "address1"}
 					<div class="required text form-group">
 						<label for="address1">{l s='Address'} <sup>*</sup></label>
-						<input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
+						<input type="text" class="text form-control validate" name="address1" id="address1" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1) && $guestInformations.address1}{$guestInformations.address1}{/if}" />
 					</div>
 					{elseif $field_name eq "address2"}
 					<div class="text{if !in_array($field_name, $required_fields)} is_customer_param{/if} form-group">
 						<label for="address2">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-						<input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
+						<input type="text" class="text form-control validate" name="address2" id="address2" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2) && $guestInformations.address2}{$guestInformations.address2}{/if}" />
 					</div>
 					{elseif $field_name eq "postcode"}
 					{$postCodeExist = true}
@@ -305,12 +305,12 @@
 						{elseif $field_name eq "address1"}
 						<div class="required form-group">
 							<label for="address1_invoice">{l s='Address'} <sup>*</sup></label>
-							<input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
+							<input type="text" class="form-control validate" name="address1_invoice" id="address1_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address1_invoice) && $guestInformations.address1_invoice}{$guestInformations.address1_invoice}{/if}" />
 						</div>
 						{elseif $field_name eq "address2"}
 						<div class="form-group{if !in_array($field_name, $required_fields)} is_customer_param{/if}">
 							<label for="address2_invoice">{l s='Address (Line 2)'}{if in_array($field_name, $required_fields)} <sup>*</sup>{/if}</label>
-							<input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
+							<input type="text" class="form-control address" name="address2_invoice" id="address2_invoice" data-validate="isAddress" value="{if isset($guestInformations) && isset($guestInformations.address2_invoice) && $guestInformations.address2_invoice}{$guestInformations.address2_invoice}{/if}" />
 						</div>
 						{elseif $field_name eq "postcode"}
 						{$postCodeExist = true}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | Hide parameters in debug trace page
| Type?         | improvement
| Category?     | FO / BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Turn off your database server and try to access to your website, on debug mode the critical parameters are hidden On prod mode you only see an error page, even in the admin folder

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
